### PR TITLE
Adding instructions to integrate with nextjs

### DIFF
--- a/docs/nextjs-integration.md
+++ b/docs/nextjs-integration.md
@@ -1,0 +1,37 @@
+---
+title: How to add the script to your NextJS site
+---
+
+You can add the script directly to your head via "next/head" or react-helmet. However there is a simpler way that also provides custom events functionality:
+
+"**[Next-Plausible](https://github.com/4lejandrito/next-plausible)**" built and maintained by [4lejandrito](https://github.com/4lejandrito). It supports:
+
+1. Serving the Plausible script:
+
+```jsx
+import PlausibleProvider from 'next-plausible'
+
+export default Home() {
+    return (
+        <PlausibleProvider domain="example.com">
+            <h1>My Site</h1>
+            ...
+        </PlausibleProvider>
+    )
+}
+```
+
+2. And sending custom events:
+
+```jsx
+import {usePlausible} from 'next-plausible'
+
+export default PlausibleButton() {
+    const plausible = usePlausible()
+    return (
+        <button onClick={() => plausible('customEventName')}>
+            Send
+        </button>
+    )
+}
+```


### PR DESCRIPTION
Hi!

I created https://github.com/4lejandrito/next-plausible to ease the integration with NextJS. I thought it might be a good idea to add it to your docs.

I really like the simplicity and ethics of Plausible. Thanks for that!