### PR TITLE
Add Vue.js plugin and Nuxt.js module

### DIFF
--- a/docs/community-integrations.md
+++ b/docs/community-integrations.md
@@ -36,6 +36,10 @@ Alternatively, you can [integrate Plausible into your site manually](plausible-s
 
 [NextJS](nextjs-integration.md): Simple integration for Plausible Aalytics and https://nextjs.org. Provides custom events functionality. Built and maintained by [4lejandrito](https://github.com/4lejandrito).
 
+## Vue.js & Nuxt.js
+
+[Vue.js & Nuxt.js](https://github.com/moritzsternemann/vue-plausible): A Vue.js plugin and NuxtJS module for Plausible Analytics. Exposes the functionality of [plausible-tracker](https://github.com/plausible/plausible-tracker) to Vue and Nuxt instances, Vue components, and Vuex stores. Built and maintained by [Moritz Sternemann](https://github.com/moritzsternemann).
+
 ## VuePress
 
 [VuePress](https://github.com/spekulatius/vuepress-plugin-plausible): A VuePress-plugin allowing you to use Plausible for your documentation website. Built and maintained by [Peter Thaleikis](https://peterthaleikis.com).


### PR DESCRIPTION
I built a Vue.js plugin and Nuxt.js module to easily integrate [plausible-tracker](https://github.com/plausible/plausible-tracker). Added them to the community-integrations docs page.