### PR TITLE
PHP integration

### DIFF
--- a/docs/integration-guides.md
+++ b/docs/integration-guides.md
@@ -157,6 +157,11 @@ Docusaurus: Check out our [Docusaurus integration page](docusaurus-integration.m
 
 Add Plausible Analytics to your [Podcastpage.io](https://podcastpage.io/) website. Just enable the Plausible Analytic script via the "Integrations" page of your dashboard to add the tracking script to all pages.
 
+## PHP
+
+Add Plausible Analytics to your [PHP page](https://plausible.io/docs/p[php-integration) website.
+
+
 ## Paste the script into the header section
 
 Alternatively, you can [integrate Plausible into your site manually](plausible-script.md) by pasting the Plausible Analytics tracking script code into the Header (`<head>`) section of your site.

--- a/docs/php-integration.md
+++ b/docs/php-integration.md
@@ -1,0 +1,25 @@
+---
+title: How to add the script to your PHP site
+---
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+You can add the  script directly to your php files, as you would do when [integrating Plausible into your site manually](https://plausible.io/docs/plausible-script):
+
+```php
+<?php
+echo '<html>';
+echo '<head>
+	<title>Your webpage</title>
+	<meta name="description" content="Example">
+	<script async defer data-domain="example.com" src="https://plausible.io/js/plausible.js"></script>
+	<link rel="stylesheet" href="CSS/main.css" type="text/css">
+</head>'; 
+echo '<body>';
+// ...
+echo '</body>';
+echo '</html>';
+?>
+```
+
+Note that if you want each page to register as a new event, this will have to be added to every page.


### PR DESCRIPTION
This shows how to add the plausible.io javascript script to a php site. This is essentially the same way to how you would do it in the manual process, but I got confused and I thought that an example might be helpful for others to come.