### PR TITLE
Changed Search API URL

### DIFF
--- a/docs/self-hosting-configuration.md
+++ b/docs/self-hosting-configuration.md
@@ -99,7 +99,7 @@ Copy the client ID and Secret into these config values:
 | GOOGLE_CLIENT_SECRET| --        | The Client Secret from the Google API Console for your Plausible Analytics project                   |
 
 After deploying those values, you can follow [the Search Console Integration docs](google-search-console-integration.md) for
-the rest of the set up. For the final step of choosing a property from the Search Console, you also need to enable the "[Google Search Console API (Legacy)](https://console.developers.google.com/apis/api/webmasters.googleapis.com)" on your Google API project.
+the rest of the set up. For the final step of choosing a property from the Search Console, you also need to enable the "[Google Search Console API](https://console.developers.google.com/apis/api/searchconsole.googleapis.com)" on your Google API project.
 
 ### Twitter Integration
 


### PR DESCRIPTION
The old legacy API doesn't exist anymore. The new one is fully backward compatible but has a different ID. Activating it makes all the domains show up in the UI.