### PR TITLE
remove cookies in CF worker

### DIFF
--- a/docs/proxy/guides/cloudflare.md
+++ b/docs/proxy/guides/cloudflare.md
@@ -44,7 +44,9 @@ async function getScript(event, extensions) {
 }
 
 async function postData(event) {
-    return await fetch("https://plausible.io/api/event", event.request);
+    const request = new Request(event.request);
+    request.headers.delete('cookie');
+    return await fetch("https://plausible.io/api/event", request);
 }
 ```
 


### PR DESCRIPTION
One of the issues with the CNAME setup was that you could receive first-party cookies of the website domain. It'd be better to not allow this to happen with the proxy setup.