### PR TITLE
Improvements to proxy documentation

### DIFF
--- a/docs/proxy/guides/cloudflare.md
+++ b/docs/proxy/guides/cloudflare.md
@@ -9,7 +9,7 @@ Step 0: Sign up for a free Cloudflare account if you don't have an account alrea
 
 ## Step 1: Create a worker
 
-In you Cloudflare account, click the dropdown on the top left and choose '[Workers](https://workers.cloudflare.com/)'. On the workers page, click on 'Create a Worker' to start configuring your proxy. Next, you'll see a page where you can edit the code for your edge worker. Remove the default code and paste the following code instead:
+In your Cloudflare account, click the dropdown on the top left and choose '[Workers](https://workers.cloudflare.com/)'. On the workers page, click on 'Create a Worker' to start configuring your proxy. Next, you'll see a page where you can edit the code for your edge worker. Remove the default code and paste the following code instead:
 
 ```js
 const ScriptName = '/js/script.js';

--- a/docs/proxy/guides/netlify.md
+++ b/docs/proxy/guides/netlify.md
@@ -43,4 +43,4 @@ the data should be sent.
 
 
 Deploy these changes to your Netlify site. You can verify the proxy is working by opening your network tab. You should see a request to
-`https://yourdomain.com.com/js/script.js` with status 200 and another one to `https://yourdomain.com.com/api/event` with status 202.
+`https://yourdomain.com/js/script.js` with status 200 and another one to `https://yourdomain.com/api/event` with status 202.


### PR DESCRIPTION
Fixed some small mistakes. See commits for details.

It's mentioned that /api/event should return 202 but the Netlify redirect has 200. Shouldn't it be 202?