### PR TITLE
Add comment in code for trailingSlash: true in config

### DIFF
--- a/docs/proxy/guides/nextjs.md
+++ b/docs/proxy/guides/nextjs.md
@@ -17,7 +17,7 @@ module.exports = {
               destination: 'https://plausible.io/js/plausible.js'
           },
           {
-              source: '/api/event',
+              source: '/api/event', // Or '/api/event/' if you have `trailingSlash: true` in this config
               destination: 'https://plausible.io/api/event'
           }
       ];


### PR DESCRIPTION
When we enable trailing slash, NextJS first routes `/api/event` to `/api/event/` and then checks for `rewrites`

I've lost a full day of analytics due to this. 😅  