### PR TITLE
Adding extra instruction in case of self-hosting

### DIFF
--- a/docs/proxy/guides/nginx.md
+++ b/docs/proxy/guides/nginx.md
@@ -39,6 +39,15 @@ server {
         proxy_set_header X-Forwarded-Host  $host;
     }
 ```
+### Step 2.5: In case you host a plausible instance
+
+Add the following configuration instructions at both `location`s
+```
+    proxy_set_header Host <your>.<plausible>.<instance>;
+    proxy_ssl_name <your>.<plausible>.<instance>;
+    proxy_ssl_server_name on;
+    proxy_ssl_session_reuse off;
+```
 
 ## Step 2: Adjust your deployed script
 
@@ -47,3 +56,4 @@ With the above config in place, you can change the script tag on your site as fo
 ```html
 <script defer data-api="https://website.com/api/event" data-domain="website.com" src="https://website.com/js/script.js"></script>
 ```
+

--- a/docs/proxy/guides/nginx.md
+++ b/docs/proxy/guides/nginx.md
@@ -39,7 +39,7 @@ server {
         proxy_set_header X-Forwarded-Host  $host;
     }
 ```
-### Step 2.5: In case you host a plausible instance
+### Step 1.5: In case you host a plausible instance(self-hosting setup, doesn't apply to the cloud version)
 
 Add the following configuration instructions at both `location`s
 ```


### PR DESCRIPTION
I found that to make it work on self-hosted domains of plausible I needed extra Nginx instructions to make it work, so here I'm adding those extra instructions for a better documentation