### PR TITLE
Add `proxy_cache` clarification to nginx guide

### DIFF
--- a/docs/proxy/guides/nginx.md
+++ b/docs/proxy/guides/nginx.md
@@ -9,6 +9,8 @@ proxy, you can also configure it to proxy your analytics. Start by adjusting you
 
 ```
 # Only needed if you cache the plausible script. Speeds things up.
+# Note: to use the `proxy_cache` setup, you'll need to make sure the `/var/run/nginx-cache`
+# directory exists (e.g. creating it in a build step with `mkdir -p /var/run/nginx-cache`)
 proxy_cache_path /var/run/nginx-cache/jscache levels=1:2 keys_zone=jscache:100m inactive=30d  use_temp_path=off max_size=100m;
 
 server {


### PR DESCRIPTION
[As detailed in this comment](https://github.com/plausible/analytics/discussions/1293#discussioncomment-1270234) the `/var/run/nginx-cache` directory needs to exist in order for the recommended `proxy_cache` setup to work, this wasn't clear from the documentation so submitting a suggested tweak here for those who run into the same issue down the line.