### PR TITLE
Fixed referrer typos

### DIFF
--- a/docs/top-referrers.md
+++ b/docs/top-referrers.md
@@ -16,21 +16,21 @@ The referral sources are counted only when they start a new session on your site
 
 There are two distinct ways that Plausible Analytics collects the referrer source for a visitor:
 
-### 1. Automatic by the `referer` header
+### 1. Automatic by the `referrer` header
 
-The `referer` header (the HTTP header is misspelled with one r for historical reasons) is the default and automated way of tracking referrer sources of web traffic. The `referer` header works well for the majority of cases but there are some limitations and fall-backs with using it for various historical and technical reasons. 
+The `referrer` header (the HTTP header is misspelled with one r for historical reasons) is the default and automated way of tracking referrer sources of web traffic. The `referrer` header works well for the majority of cases but there are some limitations and fall-backs with using it for various historical and technical reasons. 
 
 ### "Direct / None" traffic without a referrer source
 
-Not every request from a browser will have the referrer specified, and the `referer` header is not always accurate. Take a look at our blog post on the topic of [referrer header](https://plausible.io/blog/referrer-policy) for further details.
+Not every request from a browser will have the referrer specified, and the `referrer` header is not always accurate. Take a look at our blog post on the topic of [referrer header](https://plausible.io/blog/referrer-policy) for further details.
 
 You can see your "**Direct / None**" referrer source if you click on the "**details**" button. This covers all the traffic where the referrer is not passed. These could be clicks from email, clicks from documents, clicks from messengers and other mobile apps, bookmarks, people typing in the URL directly into the browser and more. You may also know it as "**dark traffic**".
 
 Here’s a non-exhaustive list of other problems with the header:
 
-* Whenever someone is moving from `http` to `https` or vice versa, the `referer` header is dropped.
+* Whenever someone is moving from `http` to `https` or vice versa, the `referrer` header is dropped.
 
-* Facebook `referer` only includes the fact that the visitor came from Facebook. Facebook never sends the post or comment ID where someone clicked.
+* Facebook `referrer` only includes the fact that the visitor came from Facebook. Facebook never sends the post or comment ID where someone clicked.
 
 * Twitter sets the referrer to their link shortener (t.co) so you can see the shortened link but not the actual tweet that brought the traffic. [We make the best effort](twitter.md) to find the tweets that visitors came from using the Twitter API and display those tweets in your dashboard. Click on "**Twitter**" to view these.
 


### PR DESCRIPTION
`referer` is invalid, should be `referrer`. Fixed here.