### PR TITLE
Add missing `results`-property

### DIFF
--- a/docs/stats-api.md
+++ b/docs/stats-api.md
@@ -134,6 +134,7 @@ curl https://plausible.io/api/v1/stats/aggregate?site_id=$SITE_ID&period=6mo&met
 
 ```json title="Response"
 {
+  "results": {
     "bounce_rate": {
         "value": 53.0
     },
@@ -146,6 +147,7 @@ curl https://plausible.io/api/v1/stats/aggregate?site_id=$SITE_ID&period=6mo&met
     "visitors": {
         "value": 201524
     }
+  }
 }
 ```
 


### PR DESCRIPTION
Example fetch for aggregated data is currently missing the `results`-prop from the response JSON.