### PR TITLE
Tar exists as file is archived

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -50,7 +50,7 @@ $ cd hosting
 Alternatively, you can download and extract the repo as a tarball
 
 ```bash
-$ curl -L https://github.com/plausible/hosting/archive/master.tar.gz | tar -x
+$ curl -L https://github.com/plausible/hosting/archive/master.tar.gz | tar -xz
 $ cd hosting-master
 ```
 


### PR DESCRIPTION
I added `z` on to the end of the tar command to fix:
```sh
tar: Archive is compressed. Use -z option
tar: Error is not recoverable: exiting now
```