### PR TITLE
Add missing steps to Search Console integration

### DIFF
--- a/docs/self-hosting-configuration.md
+++ b/docs/self-hosting-configuration.md
@@ -89,38 +89,50 @@ To run the complete setup including geoip see [`docker-compose-geoip.yml`](https
 
 ### Google Search Integration
 
-To enable the Google Search Console integration in Plausible Analytics, you need to authorize your self-hosted installation with a Google
-Account. For the OAuth flow, you need to configure the `client_id` and `client_secret`. 
+To enable the Google Search Console integration, as is described elsewhere in the [docs](google-search-console-integration.md), you first need to authorize your self-hosted installation with a Google Account. Complete the following three tasks to do so.
 
-#### Steps to Integrate Google Search Console
+#### Task One: Create an OAuth Client
 
-1. Visit the
-[Google API Console](https://console.developers.google.com/) to obtain OAuth 2.0 credentials such as a Client ID and Client Secret key that are
-known to both Google and your installation. Once on the API Console, create a new project. 
+1. Login to
+[Google API Console](https://console.developers.google.com/) with your Google Account. We will need to obtain OAuth 2.0 credentials such as a Client ID and Client Secret key that are known to both Google and your installation.
+2. Once on the API Console, create a new project for the Plausible integration.
 
 ![google1](https://user-images.githubusercontent.com/85956139/132954658-2d5bc2c3-22c2-4300-b9c6-cbe4f8f8987e.png)
 
-2. On the project, go to the "Credentials" screen and get your Client ID and Client Secret key.
+3. Make sure your new Project is open, then go to the "Credentials" screen and get your Client ID and Client Secret key. If you can't see the "Credentials" menu item, open the navigation ("hamburger") menu in the top left corner and select "APIs & Services". "Credentials" is a menu item below that.
 
 ![google2](https://user-images.githubusercontent.com/85956139/132954742-bb9c3477-b84a-40a5-a2eb-f9fa683804cf.png)
 
+4. Use the "+ CREATE CREDENTIALS" button near the top of the screen to create a new "OAuth client ID". Set the "Application type" to "Web application" and give it a name. To help with naming, note that your self-hosted Plausible site will be the "client" that is accessing an API exposed by your Google account.
+
+5. Use the "+ ADD URI" button to set an "Authorized redirect URI" to your Plausible installation's public URL followed by `/auth/google/callback`. Eg. `https://plausible.example.com/auth/google/callback`. Then click "CREATE".
+
 ![google3](https://user-images.githubusercontent.com/85956139/132954858-ef951349-20b0-4675-bf9c-ead8d4bc292b.jpg)
 
-3. Go to your Plausible installation's public URL followed by `/auth/google/callback` as "Authorized redirect URI".
-
-4. Copy the Client ID and Client Secret key from your project in Google API Console into these config values:
+6. Copy the Client ID and Client Secret key from your project in Google API Console into these config values (that is, add them to `plausible-conf.env`):
 
 | Parameter           | Default   | Description                                                                                          |
 |---------------------|-----------|------------------------------------------------------------------------------------------------------|
 | GOOGLE_CLIENT_ID    | --        | The Client ID from the Google API Console for your Plausible Analytics project                       |
 | GOOGLE_CLIENT_SECRET| --        | The Client Secret from the Google API Console for your Plausible Analytics project                   |
 
-After deploying those values, you can follow [the Search Console Integration docs](google-search-console-integration.md) for
-the rest of the set up. 
+7. Force the new config values to take effect by restarting your Plausible site (eg. with the command `docker-compose restart`).
 
-5. For the final step of choosing a property from the Search Console, you also need to enable the "[Google Search Console API](https://console.developers.google.com/apis/api/searchconsole.googleapis.com)" on your Google API project.
+#### Task Two: Configure the OAuth Consent Screen
 
-#### Enable Google Search Console API
+1. Follow the prompts or select "OAuth consent screen" from the left side menu to configure the consent screen. If you can't see the "OAuth consent screen" menu item, open the navigation ("hamburger") menu in the top left corner and select "APIs & Services". "OAuth consent screen" is a menu item below that.
+
+1. Enter an "App name" and a "User support email". Again, to help with naming, remember that the "app" is your self-hosted Plausible site which will be requesting access to the Search Console API using your Google Account, so you are probably the only user.
+
+1. Apart from the mandatory "Developer contact information" fields, the only other necessary setting is the "Authorized domains" which must include the domain used for the earlier "Authorized Redirect URIs" setting. That is, add the domain (eg. `example.com`) of your Plausible installation's public URL. All subdomains will be authorized automatically.
+
+1. Click "SAVE AND CONTINUE". No "Scopes" are required, so click "SAVE AND CONTINUE" again.
+
+1. The "app" will be created with status set to "Testing". To avoid having to verify it with Google, you must enter the email address of your Google Account as a "Test user". Add the email address and then click "SAVE AND CONTNUE" and the OAuth Consent Screen configuration is complete.
+
+#### Task Three: Enable Google Search Console API
+
+Although you can now grant your Plausible installation access to your Google account, you still will not be able to choose a property from the Search Console as described in [Google Search Console Integration](google-search-console-integration.md), until you enable the "[Google Search Console API](https://console.developers.google.com/apis/api/searchconsole.googleapis.com)" on your Google API project.
 
 1. Click on "Enable APIs and Services."
 
@@ -135,6 +147,10 @@ the rest of the set up.
 ![google_enable3](https://user-images.githubusercontent.com/85956139/132954503-df8caff9-8654-4ec0-87eb-4d76363ebc75.png)
 
 ![google_enable4](https://user-images.githubusercontent.com/85956139/132954508-290bda57-47cf-4cda-bb6d-77a1c8baa485.png)
+
+4. Finally, return to APIs & Services, and select "Domain verification". If you can't see the "Domain verification" menu item, open the navigation ("hamburger") menu in the top left corner and select "APIs & Services". "Domain verification" is a menu item below that.
+
+5. Add the same domain you used in Step 2 above. You will prompted to go to Google Search Console to finish configuration, which coincidentally is exactly where you need to be to start the [Google Search Console Integration](google-search-console-integration.md) instructions.
 
 ### Twitter Integration
 


### PR DESCRIPTION
Clarified that the "Authorized redirect URI" is a setting, not an instruction.
Clarified where the config values are set.
Improved chronology to suit a first timer, to make relationship to non-self-hosted docs clearer.
Added skipped sub-step about creating the OAuth client.
Added two complete tasks that now seem necessary: OAuth Consent Screen and Domain Verification.
Some of these omissions were quite crucial, and I know nothing of the history of this document, and I know that documenting Google Cloud is a never-ending nightmare, so I hope this is not a regression.