### PR TITLE
Document potentially link-breaking behaviour of outbound link tracking

### DIFF
--- a/docs/outbound-link-click-tracking.md
+++ b/docs/outbound-link-click-tracking.md
@@ -10,6 +10,10 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 If you use the Outbound link click tracking feature, then these count towards your billable monthly pageviews.
 :::
 
+:::caution
+Enabling this feature may break some features on your site if you're using links that open new tabs or have special event handling. See [this GitHub issue](https://github.com/plausible/plausible-tracker/issues/12) for more information.
+:::
+
 Outbound link click tracking is essential for many site owners and Plausible helps you automate this process. With our "**Outbound Link Click Tracking**" you can:
 
 * See which external URLs are clicked the most


### PR DESCRIPTION
This is an undocumented issue/limitation of the current tracker implementation. There has been some discussion in plausible/plausible-tracker#12 but no fix yet. If I understand correctly, plausible/plausible-tracker#16 could solve this.  
With this PR I'd like to propose adding a warning to the docs to prevent others from tripping over this.

Thank you for plausible! It's awesome to be able to use such a simple service without having to bother with consent banners or worry about Google trackers :heart: