### PR TITLE
Add proper caching to Cloudflare Worker guide

### DIFF
--- a/docs/proxy/guides/cloudflare.md
+++ b/docs/proxy/guides/cloudflare.md
@@ -35,7 +35,10 @@ Do avoid words like 'plausible', 'analytics', 'tracking', 'stats', etc. as they 
 const ScriptName = '/js/script.js';
 const Endpoint = '/api/event';
 
-const ScriptWithoutExtension = ScriptName.replace('.js', '')
+const CACHE_TTL_BROWSER = 86400 * 30; // 30 days
+const CACHE_TTL_PROXY = 86400 * 90; // 90 days
+
+const ScriptWithoutExtension = ScriptName.replace('.js', '');
 
 addEventListener('fetch', event => {
     event.passThroughOnException();

--- a/docs/proxy/guides/cloudflare.md
+++ b/docs/proxy/guides/cloudflare.md
@@ -58,6 +58,11 @@ async function getScript(event, extensions) {
     let response = await caches.default.match(event.request);
     if (!response) {
         response = await fetch("https://plausible.io/js/plausible." + extensions.join("."));
+        // Make a mutable copy of the (currently immutable) response object.
+        response = new Response(response.body, response);
+        // Overwrite the `Cache-Control` header to allow caching on intermediate proxies (in this case, Cloudflare), as well as on the browser.
+        response.headers.set('Cache-Control', `public, max-age=${CACHE_TTL_BROWSER}, s-maxage=${CACHE_TTL_PROXY}`);
+        // Store the fetched response (this method is non-blocking).
         event.waitUntil(caches.default.put(event.request, response.clone()));
     }
     return response;


### PR DESCRIPTION
Currently, the Cloudflare Worker appears to cache the tracking js by storing the response retrieved from `https://plausible.io/js/plausible.js` and storing it in Cloudflare's cache as is. However, due to incorrect headers being set by Plausible, the file is never cached by Cloudflare and as a result the caching operation essentially functions as a no-op. The core problem lays in the `Cache-Control` header returned by the Plausible server:
![response_plausible_js](https://user-images.githubusercontent.com/22079593/143721166-b6b18981-d688-4c27-9f25-3504f549b7ca.png)

By setting the `Cache-Control` header to `private` and `max-age` to `0`, [Cloudflare will not cache the asset](https://developers.cloudflare.com/cache/about/cache-control#cache-control-directives).  
Ideally, this would by solved by adding proper caching directives on the server. Upon checking the source, I noticed that such headers were actually [removed in a commit some time ago](https://github.com/plausible/analytics/commit/d03b31450f5e34772fa57367438c3914aef1743d). 

Assuming the removal of the caching directives was intentional (I recall reading something about it causing some issues and therefore being removed, but now I can't seem to find where I read this), I propose temporarily solving this issue by adding caching directives within the Cloudflare Worker before storing the response in the cache. This will not only allow browsers to cache the tracking js, but also Cloudflare's cache itself. I added two `const`s to allow for easy tweaking of the TTL's.

If you prefer solving this issue at the core (i.e. in Plausible's server-side code) please let me know as well, I'd be happy to take a look when I have some free time.
