### PR TITLE
Update self-hosting.md

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -148,7 +148,7 @@ You may or may not already be running a reverse proxy on your host, let's look a
 #### No existing reverse proxy
 
 If your DNS is managed by a service that offers a proxy option with automatic SSL management, feel free to use that. We've successfully
-used Cloudflare as a reverse proxy in front of Plausible Self Hosted and it works well. Please note that in this case your solution will not be completely cookie-free as Cloudflare sets cookies on your visitors' devices.
+used Cloudflare as a reverse proxy in front of Plausible Self Hosted and it works well. 
 
 Alternatively, you can run your own Caddy server as a reverse proxy. This way your SSL certificate will be stored on the
 host machine and managed by Let's Encrypt. The Caddy server will expose port 443, terminate SSL traffic and proxy the requests to your


### PR DESCRIPTION
Just noticed in the documentation that CF we're adding a cookie when reverse proxying, this hasn't been the case since 2020 as seen here :) https://blog.cloudflare.com/deprecating-cfduid-cookie/. Updating the docs to reflect