### PR TITLE
chore(docs): Add Gatsby DSG post to integration-guides

### DIFF
--- a/docs/integration-guides.md
+++ b/docs/integration-guides.md
@@ -62,9 +62,11 @@ You can run Plausible as a first party connection from your domain name. [Learn 
 
 [Flutter plugin](https://pub.dev/packages/plausible_analytics): Send pageviews and custom events to Plausible. Built and maintained by [Eric Trenkel](https://erictrenkel.com/).
 
-## GatsbyJS
+## Gatsby
 
-[GatsbyJS](https://www.gatsbyjs.org/packages/gatsby-plugin-plausible/): A Gatsby plugin for adding Plausible Analytics to your Gatsby site. Built and maintained by Curtis Cummings of [https://aquil.io/](https://aquil.io/).
+[Gatsby](https://www.gatsbyjs.com/plugins/gatsby-plugin-plausible/): A Gatsby plugin for adding Plausible Analytics to your Gatsby site. Built and maintained by Curtis Cummings of [https://aquil.io/](https://aquil.io/).
+
+In the blogpost [Using Deferred Static Generation with Plausible Analytics](https://www.lekoarts.de/gatsby/using-deferred-static-generation-with-analytics-tools) you can learn how to build a [source plugin](https://www.gatsbyjs.com/docs/how-to/plugins-and-themes/creating-a-source-plugin/#what-is-a-source-plugin) for Plausible's API and use it together with [Deferred Static Generation](https://www.gatsbyjs.com/docs/conceptual/rendering-options/#deferred-static-generation-dsg) in Gatsby.
 
 ## Ghost
 

--- a/docs/plausible-analytics-reviews.md
+++ b/docs/plausible-analytics-reviews.md
@@ -60,4 +60,6 @@ Plausible Analytics is trusted by 2,000+ subscribers to deliver their website an
 
 * [De-Google-ing your website analytics](https://changelog.com/podcast/396) by The Changelog podcast
 
+* [Using Deferred Static Generation with Plausible Analytics](https://www.lekoarts.de/gatsby/using-deferred-static-generation-with-analytics-tools) by Lennart Jörgens on lekoarts.de
+
 Let us know about any other reviews that you've published and we will feature them. Thanks for your support!

--- a/docs/plausible-analytics-reviews.md
+++ b/docs/plausible-analytics-reviews.md
@@ -60,6 +60,4 @@ Plausible Analytics is trusted by 2,000+ subscribers to deliver their website an
 
 * [De-Google-ing your website analytics](https://changelog.com/podcast/396) by The Changelog podcast
 
-* [Using Deferred Static Generation with Plausible Analytics](https://www.lekoarts.de/gatsby/using-deferred-static-generation-with-analytics-tools) by Lennart Jörgens on lekoarts.de
-
 Let us know about any other reviews that you've published and we will feature them. Thanks for your support!


### PR DESCRIPTION
Hi!

A while back I wrote: https://www.lekoarts.de/gatsby/using-deferred-static-generation-with-analytics-tools

I shows how to create a custom source plugin for Plausible in Gatsby and use that to conditionally defer pages (a new feature in Gatsby 4). Disclaimer: I work at Gatsby.

If you feel like this fits into this page, I'd be happy to see it merged. If not, not a problem :)

Thanks for Plausible!