### PR TITLE
Persist /var/run/nginx-cache on reboots

### DIFF
--- a/docs/proxy/guides/nginx.md
+++ b/docs/proxy/guides/nginx.md
@@ -11,6 +11,8 @@ proxy, you can also configure it to proxy your analytics. Start by adjusting you
 # Only needed if you cache the plausible script. Speeds things up.
 # Note: to use the `proxy_cache` setup, you'll need to make sure the `/var/run/nginx-cache`
 # directory exists (e.g. creating it in a build step with `mkdir -p /var/run/nginx-cache`)
+# To make `/var/run/nginx-cache` persist during reboots of your server
+# make sure to run `echo "D /run/nginx-cache 0755 root root -" > /usr/lib/tmpfiles.d/nginx-cache.conf`
 proxy_cache_path /var/run/nginx-cache/jscache levels=1:2 keys_zone=jscache:100m inactive=30d  use_temp_path=off max_size=100m;
 
 server {


### PR DESCRIPTION
Just bumped in this little issue while configuring a VPS to self-host plausible.

The issue on startup of nginx after a reboot:

```
root@analytics:~# service nginx status
Mar 25 08:58:05 analytics systemd[1]: Starting A high performance web server and a reverse proxy server...
Mar 25 08:58:06 analytics nginx[724]: nginx: [emerg] mkdir() "/var/run/nginx-cache/jscache" failed (2: No such file or directory)
Mar 25 08:58:06 analytics nginx[724]: nginx: configuration file /etc/nginx/nginx.conf test failed
Mar 25 08:58:06 analytics systemd[1]: nginx.service: Control process exited, code=exited, status=1/FAILURE
Mar 25 08:58:06 analytics systemd[1]: nginx.service: Failed with result 'exit-code'.
Mar 25 08:58:06 analytics systemd[1]: Failed to start A high performance web server and a reverse proxy server.
```

The `/var/run` dir seems to be cleared on reboot, and populated again by config files within `/usr/lib/tmpfiles.d`

Updated the docs a bit to include a suggestion on persisting that nginx-cache dir.

Tested on Ubuntu 20.04.4 LTS