### PR TITLE
replace yandex clickhouse-client by clickhouse

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -181,7 +181,7 @@ If you receive an error upon startup that for some reason the database does not 
 make sure that --link, --net, --host, and the name of the db  receive the right parameter values according to the running setup
 
 ```bash
-$ docker run -it --net plausible_default --rm --link plausible_events_db_1:clickhouse-server yandex/clickhouse-client --host plausible_plausible_events_db_1  --query "CREATE DATABASE IF NOT EXISTS plausible_events_db"
+$ docker run -it --net plausible_default --rm --link plausible_events_db_1:clickhouse-server clickhouse/clickhouse-client --host plausible_plausible_events_db_1  --query "CREATE DATABASE IF NOT EXISTS plausible_events_db"
 ```
 
 :::note


### PR DESCRIPTION
https://hub.docker.com/r/clickhouse/clickhouse-server is newer than https://hub.docker.com/r/yandex/clickhouse-server, which gives us confidence that as soon as client would be updated (for example with ARM build), clickhouse would be the right DockerHub repository to look for it.

Another part of https://github.com/plausible/hosting/pull/45, potentially simplifying https://github.com/ClickHouse/ClickHouse/issues/15638.