### PR TITLE
Run clickhouse-server instead of clickhouse-client

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -179,7 +179,7 @@ If you receive an error upon startup that for some reason the database does not 
 make sure that --link, --net, --host, and the name of the db  receive the right parameter values according to the running setup
 
 ```bash
-$ docker run -it --net plausible_default --rm --link plausible_events_db_1:clickhouse-server yandex/clickhouse-client --host plausible_plausible_events_db_1  --query "CREATE DATABASE IF NOT EXISTS plausible_events_db"
+docker compose exec plausible_events_db clickhouse-client --host plausible_events_db --query "CREATE DATABASE IF NOT EXISTS plausible_events_db"
 ```
 
 :::note


### PR DESCRIPTION
Per offline talk with clickhouse developers, clickhouse-client will never be updated as it's part of the server package, and the change is the recommended way of using it. Changing the invocation from clickhouse-client to clickhouse-server allows it to work under arm64, which became possible recently.