### PR TITLE
Fix CloudFront subdirectory instructions

### DIFF
--- a/docs/proxy/guides/cloudfront.md
+++ b/docs/proxy/guides/cloudfront.md
@@ -36,12 +36,6 @@ With the custom origin and behaviours in place, you can change your script tag a
 <script defer data-domain="yourdomain.com" src="/js/script.js"></script>
 ```
 
-In case of a subdirectory installation, you'll also need to add a `data-api` attribute to tell the script where the data should be sent.
-
-```html
-<script defer data-domain="yourdomain.com" data-api="/subdirectory/api/event" src="/subdirectory/js/script.js"></script>
-```
-
 Deploy these changes to your CloudFront site. You can verify the proxy is working by opening your network tab. You should see a request to
 `https://yourdomain.com/js/script.js` with status 200 and another one to `https://yourdomain.com/api/event` with status 202.
 


### PR DESCRIPTION
Subdirectory docs don't work with CloudFront. CloudFront will pass the subdirectory onto the origin. E.g., plausible/js/script.* will proxy to https://plausible.io/ plausible/js/script.js. There is no way to remove a path in CloudFront settings. We can only add a path. There is a workaround with Lambda@Edga or CloudFront functions (path rewriting) but that is a different story.