### PR TITLE
docs: use docker-compose to verify users

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -100,7 +100,7 @@ options](https://plausible.io/docs/self-hosting-configuration#mailersmtp-setup).
 Otherwise, run this command to verify all users in the database:
 
 ```bash
-$ docker exec hosting_plausible_db_1 psql -U postgres -d plausible_db -c "UPDATE users SET email_verified = true;"
+$ docker-compose exec plausible_db psql -U postgres -d plausible_db -c "UPDATE users SET email_verified = true;"
 ```
 
 > Something not working? Please reach out on our [forum](https://github.com/plausible/analytics/discussions/categories/self-hosted-support) for troubleshooting.


### PR DESCRIPTION
Today, this command uses docker to exec into the compose-created container, with an invalidly-formatted name. Instead of relying on that format being stable (and valid), this PR fixes #245 by using docker-compose for it. This only relies on the service name, which is completely under our control.