### PR TITLE
Add how to add plausible.io to the XSS protection

### DIFF
--- a/docs/discourse-integration.md
+++ b/docs/discourse-integration.md
@@ -20,6 +20,12 @@ You can add Plausible Analytics tracking code to your Discourse community by add
 
 * After adding your code, click on the "**Save**" button.
 
+Discourse has cross-site protections by default, and to allow Plausible to collect data, you need to add the Plausible URL to the setting called **content security policy script src** 
+
+* Go to Admin > Settings > search for: *content security policy script src*
+
+* Add `plausible.io` or your custom URL (i.e., `yourproxylocation.com`) as an item and click the green checkmark.
+
 Now you can go to your Discourse community and verify whether Plausible Analytics script has been added and to your Plausible Analytics account to see whether the stats are being tracked. See here [how to verify the integration](troubleshoot-integration.md).
 
 Thanks to Justin DiRose from the Discourse team for contributing [these instructions](https://meta.discourse.org/t/add-plausible-analytics-tracking-to-discourse/173310)!


### PR DESCRIPTION
Hi there!

I couldn't get these instructions to work as-is, and it turns out that there's a cross-site protection in Discourse that requires you to add another setting - thought I'd contribute this to make sure others have the full picture. 😄 