### PR TITLE
Update self-hosting.md

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -32,7 +32,7 @@ as an internal API and therefore schema changes aren't considered a breaking cha
 ## Requirements
 
 The only thing you need to install Plausible Analytics is a server with Docker installed. The server must have a CPU with x86_64 architecture
-and support for SSE 4.2 instructions. We recommend using a minimum of 4GB of RAM but the requirements will depend on your site traffic. 
+and support for SSE 4.2 instructions. Plausible Analytics has been shown to work on a server with 2GB of RAM, but the requirements will depend on your site traffic. 
 
 We've tested this on [Digital Ocean](https://m.do.co/c/91569eca0213) (affiliate link)
 but any hosting provider works. If your server doesn't come with Docker pre-installed, you can follow [their docs](https://docs.docker.com/get-docker/) to install it.


### PR DESCRIPTION
Recommending 4GB of ram can be perceived as inflating the requirements, making the SaaS look more competitive than it is. I don't think this is a perception we want our users to have.

I'm currently running Plausible on a 2GB instance, of which it uses only 644MB.