### PR TITLE
this change is needed to host the docs on BunnyCDN

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -4,7 +4,6 @@ module.exports = {
   baseUrl: '/docs/',
   favicon: 'img/favicon.png',
   organizationName: 'plausible',
-  trailingSlash: false,
   projectName: 'docs',
   scripts: [
     {src: 'https://plausible.io/js/script.js', defer: true, 'data-domain': 'plausible.io'}


### PR DESCRIPTION
While self-hosting the docs, we were able to do the URL rewrites on our own, this is not possible when storing the data on BunnyCDN. This change is needed to host single page apps on BunnyCDN.