### PR TITLE
Custom Properties

### DIFF
--- a/docs/custom-event-goals.md
+++ b/docs/custom-event-goals.md
@@ -193,47 +193,23 @@ Select `Custom event` as the goal trigger and enter the name of the custom event
 
 Next, click on the "**Add goal**" button and you'll be taken back to the Goals page. When you navigate back to your Plausible dashboard, you should see the number of visitors who triggered the custom event. Custom events are listed at the bottom of your dashboard and will appear as soon as the first conversion has been tracked.
 
-## Using custom props
+That's it. You're now tracking goal conversions.
 
-Custom properties can be attached to events to capture dynamic elements and to further break down goal conversions. You can use custom properties to create your custom metrics to collect and analyze data that Plausible doesn't automatically track.
-
-You can then filter and sort your goals by custom event properties in your Plausible dashboard. For those coming from Google Analytics, custom properties are roughly the same concept as _custom dimensions_ in Google Analytics. Custom properties can be sent both on the custom event and the pageview level. Learn more about [custom properties for pageviews here](custom-pageview-props.md).
-
-Let's say you have a contact form both in the header and footer of your site. In addition to tracking submissions, you might want to know which section of your site the form was submitted on. Instead of creating separate goals for each form, you can send a custom property instead:
-
-`plausible-event-<property>=<value>` allows you to define custom properties that are sent with your custom event. For example `plausible-event-position=footer`. The full CSS class name would look like this:
-
-`plausible-event-name=Form+Submit plausible-event-position=footer`
+## Enhanced goal conversion tracking
 
 :::note
-To represent a space character in property values, you can use a `+` sign. For example: `plausible-event-author=John+Doe`. Spaces in custom property names (`author` in this example) are not allowed.
+These three are upcoming premium features that are free-to-use during the private preview. Pricing will be announced soon.
 :::
 
-You can have up to 30 custom props classes. And the names can be anything that you want.
+### Attach custom properties
 
-Custom properties only accept scalar values such as strings, numbers and booleans. Data structures such as objects, arrays etc. aren't accepted.
+Custom properties can be attached to events to capture dynamic elements and to further break down goal conversions. You can use custom properties to create your custom metrics to collect and analyze data that Plausible doesn't automatically track. [Learn more here](/custom-props/for-custom-events).
 
-Custom properties will show up automatically on your dashboard as long as you've added the goal itself. You don't need to manually add them in your settings.
-
-Plausible will display `(none)` in your dashboard when you send a custom property key with no value, or `null`/`undefined` as a value.
-
-Note that you must ensure that no personally identifiable information (PII) is sent to Plausible with custom properties. PII is information that could be used on its own to identify, contact, or precisely locate an individual. This includes:
-
-* full names or usernames
-* email addresses
-* mailing addresses
-* phone numbers
-* credit card information
-* passport numbers
-* precise locations
-* IP addresses
-* pseudonymous cookie IDs, advertising IDs or other pseudonymous end user identifiers
-
-## Sending monetary values to track ecommerce revenue
+### Monetary values to track ecommerce revenue
 
 You can also send dynamic monetary values alongside custom events to track revenue attribution. Here's how to set up the [ecommerce revenue tracking](ecommerce-revenue-tracking.md).
 
-## Creating funnels to optimize your conversion rate
+### Create funnels to optimize your conversion rate
 
 After you have the custom events in place, you can start creating [marketing funnels](funnel-analysis.md) to uncover possible issues, optimize your site and increase the conversion rate.
 
@@ -260,16 +236,24 @@ Here's what triggering a custom event looks like:
 plausible('Signup')
 ```
 
-The event name can be anything. As a second parameter, you can also send an object with options. The supported options at the moment are:
+The first argument to this function ("Signup" in this case) is the name of your custom event (i.e. the name of your goal).
+
+The second (optional) argument to the `plausible` function is an object with that currently supports the following options: 
 
 * `callback` – a function that is called once the event is logged successfully.
-* `props` – an object with custom properties for the event
+* `props` - an object with custom properties. Read more and see examples [here](/custom-props/for-custom-events)
+* `revenue` - an object with revenue tracking fields. Read more and see examples [here](ecommerce-revenue-tracking.md)
 
-And here's what triggering a custom event with custom properties looks like:
+Here's an example of the options argument using the `callback` and `props` options. 
 
 ```javascript
-plausible('Download', {props: {method: 'HTTP', Region: 'Europe'}})
+plausible('Download', {callback: navigateFn, props: {method: 'HTTP'}})
 ```
+
+:::note
+Custom properties and revenue tracking are upcoming premium features that are currently free-to-use during the private preview. Pricing will be announced soon.
+:::
+
 <h3>
 
 Example: Tracking audio and video elements

--- a/docs/custom-props/for-custom-events.md
+++ b/docs/custom-props/for-custom-events.md
@@ -1,0 +1,58 @@
+---
+title: Attach custom properties to custom events
+---
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+:::note
+Custom properties is an upcoming premium feature that's free-to-use during the private preview. Pricing will be announced soon.
+:::
+
+The process of attaching custom properties to your custom events is different depending on how you're sending your events to Plausible.
+
+## 1. Using the `tagged-events` script extension
+
+Here's how you can attach custom properties if you're tracking your custom events with the `tagged-events` script extension.
+
+In this case, your tracking script should already include the `tagged-events`` script extension:
+
+```html
+<script defer data-domain="yourdomain.com" src="https://plausible.io/js/script.tagged-events.js"></script>
+```
+
+Now, let's say you have a contact form both in the header and footer of your site. In addition to tracking submissions, you might want to know which section of your site the form was submitted on. Instead of creating separate goals for each form, you can send a custom property instead:
+
+Similarly to how you define an event name inside the `class` attribute, you can use the format `plausible-event-<property>=<value>` to define custom properties. Following the same example, your code might look something like this:
+
+```html
+<body>
+  <!-- header -->
+  <form class="plausible-event-name=Form+Submit plausible-event-position=header">...</form>
+
+  <!-- footer -->
+  <form class="plausible-event-name=Form+Submit plausible-event-position=footer">...</form>
+</body>
+```
+
+Now, both form submissions would trigger the same `Form Submit` event, but the `position` property will be different.
+
+:::note
+To represent a space character in property values, you can use a `+` sign. This is because you can't include the space character in the `class` attribute.
+:::
+
+You can add up to 30 classes for custom properties. Simply separate them with a space character like in the above example.
+
+## 2. Using the manual method
+
+If you're sending your custom events manually with JavaScript, for example:
+
+```js
+plausible('Download')
+```
+
+All you have to do is add the second argument to this function call with the custom properties as follows:
+
+```js
+plausible('Download', {props: {method: 'HTTP', position: 'footer'}})
+```
+

--- a/docs/custom-props/for-pageviews.md
+++ b/docs/custom-props/for-pageviews.md
@@ -1,5 +1,5 @@
 ---
-title: Custom properties for pageviews
+title: Attach custom properties to pageviews
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
@@ -7,21 +7,6 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 :::note
 Custom properties is an upcoming premium feature that's free-to-use during the private preview. Pricing will be announced soon.
 :::
-
-You can attach custom properties (also known as custom dimensions in Google Analytics) when sending a pageview to Plausible in order to create custom metrics. Custom properties for pageviews allow you to collect and analyze metrics that we don't track automatically. 
-
-For example, say you want to track your blog posts by `author`. Every time a visitor lands on one of the posts, you can send a pageview with the property `author=...`. You can then filter your Plausible dashboard by a specific author to see all the relevant stats for the posts published by that particular writer.
-
-Some other examples of stats you can get by sending custom properties alongside pageviews:
-
-* Filter content by the publication date, page type, ID, tag or category
-* Filter visitors by login status or user role
-* Filter visitors by language they're viewing your website in
-* Filter visitors by how many prefer or use the dark mode
-* Filter visitors by level completions or high score if you're a game developer
-* Filter by the segment that saw a particular variation of your site which is useful for A/B testing
- 
-In order to use this feature you have to start sending custom properties with pageviews from your website. Here's how you can do that:
 
 ## 1. Change the Plausible snippet on your site
 
@@ -59,21 +44,9 @@ All properties provided in the snippet will automatically be attached to any [cu
 
 That's it! You're now tracking custom properties alongside pageviews.
 
-## 3. Filter your dashboard by custom properties
-
-As soon as you have at least one pageview sent with a custom property, you will be able to see an option to filter by that property in your Plausible dashboard. To do that, open up the filter dropdown menu and select "**Property**".
-
-<img alt="Custom Property Filter" src={useBaseUrl('img/custom-property-filter.png')} />
-
-In that view you can interact with the dropdown fields, where Plausible will automatically provide filtering suggestions based on the custom properties for pageviews that we have recorded. The suggestions also take into account the selected time period and other filters already applied.
-
-Choose the custom property that you want to analyze and click on "**Apply Filter**" to filter your dashboard. Note that you can only filter by one custom property at a time.
-
-<img alt="Custom Property Filter" src={useBaseUrl('img/prop-filter-modal.png')} />
-
 ## Using `script.manual.js` as an alternative
 
-As an alternative, you can also use our `manual` script extension to send custom properties for pageviews. It works exactly the same way as with [custom properties for custom events](custom-event-goals.md#using-custom-props). For example:
+As an alternative, you can also use our `manual` script extension to send custom properties for pageviews. It works exactly the same way as with [custom properties for custom events](/custom-props/for-custom-events#2-using-the-manual-method). Make sure to write `pageview` exactly the same as in the following example:
 
 ```javascript
 plausible('pageview', {props: {author: 'John Doe', logged_in: 'false'}})

--- a/docs/custom-props/introduction.md
+++ b/docs/custom-props/introduction.md
@@ -1,0 +1,59 @@
+---
+title: Introduction to custom properties
+---
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+:::note
+Custom properties is an upcoming premium feature that's free-to-use during the private preview. Pricing will be announced soon.
+:::
+
+You can attach custom properties (also known as custom dimensions in Google Analytics) when sending pageviews or custom events to Plausible in order to create custom metrics. Custom properties allow you to collect and analyze metrics that we don't track automatically. 
+
+For example, say you want to track your blog posts by `author`. Every time a visitor lands on one of the posts, you can send a pageview with the property `author=...`. You can then filter your Plausible dashboard by a specific author to see all the relevant stats for the posts published by that particular writer.
+
+Some other examples of stats you can get by sending custom properties:
+
+* Filter content by the publication date, page type, ID, tag or category
+* Filter visitors by login status or user role
+* Filter visitors by language they're viewing your website in
+* Filter visitors by how many prefer or use the dark mode
+* Filter visitors by level completions or high score if you're a game developer
+* Filter by the segment that saw a particular variation of your site which is useful for A/B testing
+
+## Personally identifiable information
+
+Note that you must ensure that no personally identifiable information (PII) is sent to Plausible with custom properties. PII is information that could be used on its own to identify, contact, or precisely locate an individual. This includes:
+
+* full names or usernames
+* email addresses
+* mailing addresses
+* phone numbers
+* credit card information
+* passport numbers
+* precise locations
+* IP addresses
+* pseudonymous cookie IDs, advertising IDs or other pseudonymous end user identifiers
+
+## `(none)` values
+
+Plausible will display `(none)` in your dashboard when you send a custom property key with no value, or `null`/`undefined` as a value. Also, when you send one event with a property (e.g. `author`) and another event with the same name, but without the `author` property, then you will also see the `(none)` value because the property has not been sent with every event.
+
+## Accepted values
+
+Custom properties only accept scalar values such as strings, numbers and booleans. Data structures such as objects, arrays etc. aren't accepted.
+
+## Limits
+
+* You can send up to 30 different custom props per event
+* The number of allowed characters for a property name is 300
+* The limit for custom property values is 2000 characters 
+
+## Set up custom property tracking
+
+Please check out the following sections of instructions for setting up the tracking and analyzing the data in your dashboard:
+
+* [Attach custom properties to pageviews](/custom-props/for-pageviews)
+* [Attach custom properties to custom events](/custom-props/for-custom-events)
+* [Analyze your traffic by custom properties](/custom-props/props-dashboard)
+

--- a/docs/custom-props/props-dashboard.md
+++ b/docs/custom-props/props-dashboard.md
@@ -1,0 +1,33 @@
+---
+title: Analyze your traffic by custom properties
+---
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+:::note
+Custom properties is an upcoming premium feature that's free-to-use during the private preview. Pricing will be announced soon.
+:::
+
+## 1. Configure properties in your Site Settings
+
+Before any properties will be visible in your dashboard, you have to explicitly configure them. In your [site settings](website-settings.md), navigate to the Properties section, where you can add and remove properties that are displayed on your dashboard.
+
+You also have the option to enable all properties that you've already sent with one click.
+
+## 2. Filter by a custom property
+
+As soon as you have at least one event with a custom property, you will be able to see an option to filter by that property in your Plausible dashboard. To do that, open up the filter dropdown menu and select "**Property**".
+
+<img alt="Custom Property Filter" src={useBaseUrl('img/custom-property-filter.png')} />
+
+In that view you can interact with the dropdown fields, where Plausible will automatically provide filtering suggestions based on the custom properties for pageviews that we have recorded. The suggestions also take into account the selected time period and other filters already applied.
+
+Choose the custom property that you want to analyze and click on "**Apply Filter**" to filter your dashboard. Note that you can only filter by one custom property at a time.
+
+<img alt="Custom Property Filter" src={useBaseUrl('img/prop-filter-modal.png')} />
+
+## 3. Break down your traffic by a custom property
+
+At the bottom of your dashboard, you have the Behaviors section which allows you to switch to the "**Properties**" tab on the top right.
+
+In this view, you can select a property to see the value breakdown for.

--- a/docs/events-api.md
+++ b/docs/events-api.md
@@ -119,10 +119,11 @@ So if you send `https://some.domain.com/example-path`, it will be parsed as foll
 
 **props** <Optional />
 
-Custom properties for the event. These can be attached to both pageview and custom events. To learn more about using custom properties, you can check out these two links:
+:::note
+Custom properties is an upcoming premium feature that's free-to-use during the private preview. Pricing will be announced soon.
+:::
 
-* [custom properties for pageviews](https://plausible.io/docs/custom-pageview-props)
-* [custom properties for custom events](https://plausible.io/docs/custom-event-goals#using-custom-props)
+Custom properties for the event. These can be attached to both pageviews and custom events. Learn more about using custom properties [here](/custom-props/introduction).
 
 The value corresponding to the `props` key in the request body is expected to be a JSON object with a maximum of 30 key-value pairs. If you include more than 30 items in the `props` object, the exceeding items will be discarded. For example, if you're using the `text/plain` content type, your request body might look like this:
 
@@ -132,6 +133,10 @@ The value corresponding to the `props` key in the request body is expected to be
 <hr / >
 
 **revenue** <Optional />
+
+:::note
+Revenue tracking is an upcoming premium feature that's free-to-use during the private preview. Pricing will be announced soon.
+:::
 
 Revenue data for this event. This can be attached to goals and custom events to track revenue attribution. To learn more about revenue tracking and how you can set up your dashboard before sending revenue data, please read [this document](ecommerce-revenue-tracking.md).
 

--- a/docs/goal-conversions.md
+++ b/docs/goal-conversions.md
@@ -16,7 +16,7 @@ There are several types of behavior analytics tools in Plausible Analytics:
 * [Custom event goals](custom-event-goals.md) allow you to measure button clicks, purchases, subscriptions, form completions, clicks on video or audio elements and pretty much any other action that you wish (you can also send custom dimensions alongside custom events for extra insights)
 * [Funnel analysis](funnel-analysis.md) allow you to follow the visitor journey from a landing page to a conversion in order to to uncover possible issues, optimize your site and increase the conversion rate.
 * [Ecommerce revenue tracking](ecommerce-revenue-tracking.md) allows you to assign dynamic monetary values to goals and custom events to track revenue attribution.
-* [Custom properties for pageviews](custom-pageview-props.md) allow you to send custom data when sending a pageview to create custom metrics.
+* [Custom properties](/custom-props/introduction) allow you to send custom data with pageviews and custom events to create custom metrics.
 * [Outbound link clicks](outbound-link-click-tracking.md) allow you to automatically measure clicks on external links
 * [File downloads](file-downloads-tracking.md) allow you to automatically track when a visitor clicks a link leading to a file
 * [404 error pages](error-pages-tracking-404.md) allow you to automatically measure page not found errors

--- a/docs/metrics-definitions.md
+++ b/docs/metrics-definitions.md
@@ -29,7 +29,7 @@ unique conversions for a goal / unique visitors, where both values depend on the
 
 ## Custom Properties (or Custom Dimensions)
 
-You can attach custom data when sending [a pageview](custom-pageview-props.md) or [a custom event](custom-event-goals.md#using-custom-props) to Plausible in order to create custom metrics.
+You can attach custom data when sending pageviews and custom events in order to create custom metrics. Learn more [here](/custom-props/introduction)
 
 ## Current Visitors
 

--- a/docs/script-extensions.md
+++ b/docs/script-extensions.md
@@ -35,7 +35,7 @@ Here's the list of all the available extensions at this time:
 | script.file-downloads.js | Automatically [track file downloads](file-downloads-tracking.md)                                   |
 | script.tagged-events.js  | Allows you to [track standard custom events](custom-event-goals.md) such as link clicks, form submits, and any other HTML element clicks            |
 | script.revenue.js  | Allows you to assign dynamic [monetary values](ecommerce-revenue-tracking.md) to goals and custom events to track revenue attribution |
-| script.pageview-props.js  | Allow you to attach [custom properties](custom-pageview-props.md) (also known as custom dimensions in Google Analytics) when sending a pageview in order to create custom metrics      |
+| script.pageview-props.js  | Allow you to attach [custom properties](/custom-props/introduction) (also known as custom dimensions in Google Analytics) when sending a pageview in order to create custom metrics      |
 | script.exclusions.js     | [Exclude certain pages from being tracked](excluding-pages.md)                                     |
 | script.compat.js         | Compatibility mode for [tracking users on Internet Explorer](#scriptcompatjs) (≥IE11)                      |
 | script.local.js          | Allow analytics to track on localhost too which is useful in hybrid apps                           |

--- a/docs/stats-api.md
+++ b/docs/stats-api.md
@@ -88,7 +88,7 @@ more depth. Here's the full list of properties we collect automatically:
 
 #### Custom props
 
-In addition to props that are collected automatically, you can also query for [custom properties](/custom-event-goals#using-custom-props).
+In addition to props that are collected automatically, you can also query for [custom properties](/custom-props/introduction).
 To filter or break down by a custom property, use the key `event:props:<custom_prop_name>`. [See example](#breakdown-custom-event-by-custom-props) for how to use it.
 
 :::note

--- a/sidebars.js
+++ b/sidebars.js
@@ -53,8 +53,17 @@ module.exports = {
       'file-downloads-tracking',
       'error-pages-tracking-404',
       'pageview-goals',
-      'custom-pageview-props',
       'custom-event-goals',
+      {
+        type: 'category',
+        label: 'Custom properties',
+        items: [
+          'custom-props/introduction',
+          'custom-props/for-pageviews',
+          'custom-props/for-custom-events',
+          'custom-props/props-dashboard',
+        ]
+      },
       {
         type: 'category',
         label: 'Custom events CMS guides',

--- a/sidebars.js
+++ b/sidebars.js
@@ -1,26 +1,116 @@
 module.exports = {
   someSidebar: {
-    "Get Started": ['introduction', 'register-account', 'add-website', 'plausible-script', 'script-extensions', 'integration-guides', 'troubleshoot-integration', 'your-plausible-experience'],
-    "Website Settings": ['landing-page', 'website-settings', 'change-domain-name', 'general', 'users-roles', 'visibility', 'shared-links', 'embed-dashboard', 'email-reports', 'traffic-spikes', 'slack-reports', 'excluding-pages', 'transfer-ownership', 'reset-site-data', 'delete-site-data', 'excluding'],
-    "Stats Dashboard": ['guided-tour', 'compare-stats', 'filters-segments', 'manual-link-tagging', 'google-analytics-import', 'google-search-console-integration', 'realtime-dashboard', 'top-referrers', 'top-pages', 'countries', 'devices', 'export-stats', 'metrics-definitions', 'keyboard-shortcuts', 'dashboard-faq'],
-    "Events, Funnels and Ecommerce": ['goal-conversions', 'funnel-analysis', 'ecommerce-revenue-tracking', 'outbound-link-click-tracking', 'file-downloads-tracking', 'error-pages-tracking-404', 'pageview-goals', 'custom-pageview-props', 'custom-event-goals',
+    "Get Started": [
+      'introduction',
+      'register-account',
+      'add-website',
+      'plausible-script',
+      'script-extensions',
+      'integration-guides',
+      'troubleshoot-integration',
+      'your-plausible-experience'
+    ],
+    "Website Settings": [
+      'landing-page',
+      'website-settings',
+      'change-domain-name',
+      'general',
+      'users-roles',
+      'visibility',
+      'shared-links',
+      'embed-dashboard',
+      'email-reports',
+      'traffic-spikes',
+      'slack-reports',
+      'excluding-pages',
+      'transfer-ownership',
+      'reset-site-data',
+      'delete-site-data',
+      'excluding'
+    ],
+    "Stats Dashboard": [
+      'guided-tour',
+      'compare-stats',
+      'filters-segments',
+      'manual-link-tagging',
+      'google-analytics-import',
+      'google-search-console-integration',
+      'realtime-dashboard',
+      'top-referrers',
+      'top-pages',
+      'countries',
+      'devices',
+      'export-stats',
+      'metrics-definitions',
+      'keyboard-shortcuts',
+      'dashboard-faq'
+    ],
+    "Events, Funnels and Ecommerce": [
+      'goal-conversions',
+      'funnel-analysis',
+      'ecommerce-revenue-tracking',
+      'outbound-link-click-tracking',
+      'file-downloads-tracking',
+      'error-pages-tracking-404',
+      'pageview-goals',
+      'custom-pageview-props',
+      'custom-event-goals',
       {
         type: 'category',
         label: 'Custom events CMS guides',
-        items: ['webflow-integration', 'shopify-integration', 'carrd-integration'],
+        items: [
+          'webflow-integration',
+          'shopify-integration',
+          'carrd-integration'
+        ],
       }
     ],
-    "API": ['stats-api',  'events-api', 'sites-api'],
-    "Adblockers": ['proxy/introduction',
+    "API": [
+      'stats-api',
+      'events-api',
+      'sites-api'
+    ],
+    "Adblockers": [
+      'proxy/introduction',
       {
         type: 'category',
         label: 'Guides',
-        items: ['proxy/guides/cloudflare', 'proxy/guides/wordpress', 'proxy/guides/akamai', 'proxy/guides/netlify', 'proxy/guides/vercel', 'proxy/guides/nextjs', 'proxy/guides/cloudfront', 'proxy/guides/nginx', 'proxy/guides/caddy', 'proxy/guides/apache'],
+        items: [
+          'proxy/guides/cloudflare',
+          'proxy/guides/wordpress',
+          'proxy/guides/akamai',
+          'proxy/guides/netlify',
+          'proxy/guides/vercel',
+          'proxy/guides/nextjs',
+          'proxy/guides/cloudfront',
+          'proxy/guides/nginx',
+          'proxy/guides/caddy',
+          'proxy/guides/apache'
+        ],
       }
     ],
-    "Account Settings": ['change-email', 'reset-password', 'dashboard-appearance', 'delete-account'],
-    "Billing and Subscription": ['trial-to-paid', 'subscription-plans', 'change-plan', 'cancel-subscription', 'download-invoices', 'billing'],
-    "Self-Hosting": ['self-hosting', 'self-hosting-configuration'],
-    "Contribute": ['contribute', 'plausible-analytics-reviews', 'authors'],
+    "Account Settings": [
+      'change-email',
+      'reset-password',
+      'dashboard-appearance',
+      'delete-account'
+    ],
+    "Billing and Subscription": [
+      'trial-to-paid',
+      'subscription-plans',
+      'change-plan',
+      'cancel-subscription',
+      'download-invoices',
+      'billing'
+    ],
+    "Self-Hosting": [
+      'self-hosting',
+      'self-hosting-configuration'
+    ],
+    "Contribute": [
+      'contribute',
+      'plausible-analytics-reviews',
+      'authors'
+    ],
   },
 };


### PR DESCRIPTION
A bigger documentation update for the whole props feature. This removes the separation of custom event vs pageview props (except the instructions on how to send them).