### PR TITLE
mention releases page in 'Version management' section

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -25,7 +25,7 @@ You can find available Plausible versions on [DockerHub](https://hub.docker.com/
 None of the functionality is backported to older versions. If you wish to get the latest bug fixes and security
 updates you need to upgrade to a newer version.
 
-Version changes are documented in our [Changelog](https://github.com/plausible/analytics/blob/master/CHANGELOG.md).
+New versions are published on [the releases page](https://github.com/plausible/analytics/releases) and their changes are documented in our [Changelog](https://github.com/plausible/analytics/blob/master/CHANGELOG.md).
 Please note that database schema changes require running migrations when you're upgrading. However, we consider the schema
 as an internal API and therefore schema changes aren't considered a breaking change.
 


### PR DESCRIPTION
As promised in https://github.com/plausible/analytics/discussions/1459#discussioncomment-6687216

> Maybe it's worth adding this to the official documentation, so you don't have to worry and go through links looking for solutions, you know, not what you want to do.