### PR TITLE
Clarify request types in cloudfront proxy documentation

### DIFF
--- a/docs/proxy/guides/cloudfront.md
+++ b/docs/proxy/guides/cloudfront.md
@@ -36,8 +36,8 @@ With the custom origin and behaviours in place, you can change your script tag a
 <script defer data-domain="yourdomain.com" src="/js/script.js"></script>
 ```
 
-Deploy these changes to your CloudFront site. You can verify the proxy is working by opening your network tab. You should see a request to
-`https://yourdomain.com/js/script.js` with status 200 and another one to `https://yourdomain.com/api/event` with status 202.
+Deploy these changes to your CloudFront site. You can verify the proxy is working by opening your network tab. You should see a GET request to
+`https://yourdomain.com/js/script.js` with status 200 and a POST request to `https://yourdomain.com/api/event` with status 202.
 
 Using our extensions such as hash-based routing, page exclusions or outbound link click tracking? Change the file name from script.js to the script you want to use: script.hash.js, script.exclusions.js or script.outbound-links.js. Want to use more than one extension? You can chain them like this: script.hash.exclusions.outbound-links.js.
 


### PR DESCRIPTION
I just wanted to clarify what types of requests to `/js/script.js` and `/api/event` would result in successful responses. I spent a lot of time wondering why a GET request to `/api/event` would 404 instead of returning a 202. Sending a POST request via curl seems to be fine, and the API docs seem to indicate there isn't a GET request for `/api/event` so it doesn't seem like it's a problem for that to 404.