### PR TITLE
Reapply Stats API conversion rate docs

### DIFF
--- a/docs/stats-api.md
+++ b/docs/stats-api.md
@@ -42,6 +42,7 @@ You can specify a `metrics` option in the query, to choose the metrics for each 
 | `bounce_rate`     | Bounce rate percentage                                                                                                                                    |
 | `visit_duration`  | Visit duration in seconds                                                                                                                                 |
 | `events`          | The number of events (pageviews + custom events)                                                                                                          |
+| `conversion_rate` | The percentage of visitors who completed the goal. Requires an `event:goal` filter or `event:goal` property in the breakdown endpoint                     |
 
 ### Time periods
 
@@ -195,7 +196,11 @@ See [time periods](#time-periods). If not specified, it will default to `30d`.
 
 **metrics** <Optional />
 
-List of metrics to aggregate. Valid options are `visitors`, `visits`, `pageviews`, `views_per_visit`, `bounce_rate`, `visit_duration` and `events`. If not specified, it will default to `visitors`.
+List of metrics to aggregate. Valid options are `visitors`, `visits`, `pageviews`, `views_per_visit`, `bounce_rate`, `visit_duration`, `events` and `conversion_rate`. If not specified, it will default to `visitors`.
+
+:::note
+You can only query `conversion_rate` when filtering by a `event:goal`. 
+:::
 
 <hr / >
 
@@ -354,8 +359,11 @@ See [time periods](#time-periods). If not specified, it will default to `30d`.
 
 **metrics** <Optional />
 
-Comma-separated list of metrics to show for each item in breakdown. Valid options are `visitors`, `pageviews`, `bounce_rate`, `visit_duration`, `visits` and `events`. If not
-specified, it will default to `visitors`.
+Comma-separated list of metrics to show for each item in breakdown. Valid options are `visitors`, `pageviews`, `bounce_rate`, `visit_duration`, `visits`, `events` and `conversion_rate`. If not specified, it will default to `visitors`.
+
+:::note
+You can only query `conversion_rate` when filtering by `event:goal` or breaking down on the `event:goal` property. 
+:::
 
 <hr / >
 


### PR DESCRIPTION
Reapplying the documentation for the conversion rate metric in Stats API.

This reverts commit 00c7b48032a3480864494926e24b8a73f7df4212, reversing changes made to 6cd039cab221dc2129f550c49684cd96f602085a.