### PR TITLE
Fix asterisk opening `em` tag

### DIFF
--- a/docs/squarespace-integration.md
+++ b/docs/squarespace-integration.md
@@ -71,4 +71,4 @@ In Squarespace, all completed orders are being redirected to a page with the fol
 
 `https://yourwebsite.com/commerce/orders/977f8aa0-f618-47d0-8787-ee37b1457cc0`
 
-To track completed orders, you can set up a pageview goal. Since the ID (in our example `/977f8aa0-f618-47d0-8787-ee37b1457cc0`) changes with every order, you will need to group those dynamic pages. You can use asterisks (*) to do so. Asterisks can be placed on either end or in the middle of any page path URL. For the example above, you can set up a pageview goal `/commerce/orders/*` to group all of the dynamically created order completion pages.
+To track completed orders, you can set up a pageview goal. Since the ID (in our example `/977f8aa0-f618-47d0-8787-ee37b1457cc0`) changes with every order, you will need to group those dynamic pages. You can use asterisks (&ast;) to do so. Asterisks can be placed on either end or in the middle of any page path URL. For the example above, you can set up a pageview goal `/commerce/orders/*` to group all of the dynamically created order completion pages.


### PR DESCRIPTION
Since I don't know the templating engine used, I can only speculate on how to solve this problem. `&ast;` may not work in the code block, `\*` may not escape properly.