### PR TITLE
drop time on page from CSV docs

### DIFF
--- a/docs/csv-import.md
+++ b/docs/csv-import.md
@@ -4,7 +4,7 @@ title: Import stats using CSV files
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-Plausible Analytics allows you to import your historical stats from various analytics tools using CSV files. This also makes it possible to migrate your stats [from Plausible Community Edition (CE) to our official managed hosting (or vice-versa)](https://plausible.io/self-hosted-web-analytics). 
+Plausible Analytics allows you to import your historical stats from various analytics tools using CSV files. This also makes it possible to migrate your stats [from Plausible Community Edition (CE) to our official managed hosting (or vice-versa)](https://plausible.io/self-hosted-web-analytics).
 
 You can import multiple different properties into the same Plausible dashboard using CSVs. In addition to CSV file imports, you can also import your Google Analytics stats to the same Plausible dashboard.
 
@@ -20,7 +20,7 @@ Here's how you can import your historical stats into your Plausible dashboard by
 
 2. Go into the "**Imports & Exports**" section, find the "**Import Data**" panel and click on the "**CSV**" button to import your CSV files.
 
-4. Select all the CSV files that you'd like to import and click on the "**Confirm import**" button. When importing your stats from different analytics tools, please ensure that each CSV file follows our CSV format guidelines. The guidelines are listed at the end of this document. 
+3. Select all the CSV files that you'd like to import and click on the "**Confirm import**" button. When importing your stats from different analytics tools, please ensure that each CSV file follows our CSV format guidelines. The guidelines are listed at the end of this document.
 
 :::tip Want to transfer a site ownership to another Plausible account?
 No data export/import is needed in this case. We have a way to [transfer site ownership](transfer-ownership.md) with a couple of clicks.
@@ -38,7 +38,7 @@ Make sure to upgrade your self-hosted instance to Plausible CE version 2.1 or hi
 
 1. First you need to export your stats. Go to the Plausible [site settings](website-settings.md) for the website you'd like to export the data for.
 
-2. Go into the "**Imports & Exports**" section, find the "**Export Data**" panel and click on the "**Export to CSV**" button to export all the data. 
+2. Go into the "**Imports & Exports**" section, find the "**Export Data**" panel and click on the "**Export to CSV**" button to export all the data.
 
 3. Then go to the site you'd like to import the data to. In the "**Imports & Exports**" section, find the "**Import Data**" panel and click on the "**CSV**" button to import your CSV files.
 
@@ -48,13 +48,13 @@ Make sure to upgrade your self-hosted instance to Plausible CE version 2.1 or hi
 
 ## Multiple imports into the same Plausible dashboard
 
-If you'd like to make several imports into the same Plausible dashboard, please go through the process above again and choose different CSV files to import. You can import a maximum of 5 different properties into one Plausible dashboard. You can import using both of our import methods (CSV files and Google Analytics import) into the same Plausible dashboard. 
+If you'd like to make several imports into the same Plausible dashboard, please go through the process above again and choose different CSV files to import. You can import a maximum of 5 different properties into one Plausible dashboard. You can import using both of our import methods (CSV files and Google Analytics import) into the same Plausible dashboard.
 
 In the "**Imports & Exports**" section, you can see the overview of all your existing imports to that specific Plausible dashboard. For each import, we list the ID, the number of pageviews imported and the time range that the import covers.
 
 ## How much data is imported?
 
-Data is imported in aggregate for each date, from your first import visitor until your first Plausible Analytics visitor. This is to avoid double-counting visits. We also have measures in place to detect and avoid double-counting visitors if you import multiple properties into the same Plausible dashboard. 
+Data is imported in aggregate for each date, from your first import visitor until your first Plausible Analytics visitor. This is to avoid double-counting visits. We also have measures in place to detect and avoid double-counting visitors if you import multiple properties into the same Plausible dashboard.
 
 ## How can I delete imported data?
 
@@ -64,7 +64,7 @@ Data you have imported can be deleted by returning to your site's "**Imports & E
 
 We have taken many steps to make the imported data feel as fast, easy, and straightforward as the native data. But it's important to note that imported data won't be as flexible as the native data that we collect using our script. Here are the differences:
 
-### Filtering 
+### Filtering
 
 It isn't possible to use [our filters](filters-segments.md) with the imported data.
 
@@ -98,7 +98,7 @@ For example, a file named `imported_devices_20230209_20240123.csv` includes data
 
 Below, you'll find the structure for each CSV file to be imported into Plausible Analytics. It's important to note that while all files and columns within those files are optional, to maintain completeness and avoid gaps in your dashboard, it's recommended that all files be present and fully populated according to the structures outlined here. For metric definitions, please refer to [this document](https://plausible.io/docs/metrics-definitions).
 
-It's important to note that metrics such as `visitors`, `visits`, `bounces`, `pageviews`, and similar are intended to represent total counts within the specified dimension, not averages. And metrics such as `visit_duration` and `time_on_page` represent total duration in seconds.
+It's important to note that metrics such as `visitors`, `visits`, `bounces`, `pageviews`, and similar are intended to represent total counts within the specified dimension, not averages. And metrics such as `visit_duration` represent total duration in seconds.
 
 #### imported_browsers
 
@@ -244,31 +244,25 @@ $ head imported_operating_systems_20230209_20240123.csv
 
 #### imported_pages
 
-| date | hostname | page   | visits | visitors | pageviews | exits  | time_on_page |
-| ---- | -------- | ------ | ------ | -------- | --------- | ------ | ------------ |
-| Date | String   | String | UInt64 | UInt64   | UInt64    | UInt64 | UInt64       |
-|      |          |        | count  | count    | count     | count  | seconds      |
-
-- `exits` are only necessary if `pageviews` count includes them, if both are included, average `time_on_page` in the dashboard is calculated as
-
-  ```
-  time_on_page / (pageviews - exits)
-  ```
+| date | hostname | page   | visits | visitors | pageviews |
+| ---- | -------- | ------ | ------ | -------- | --------- |
+| Date | String   | String | UInt64 | UInt64   | UInt64    |
+|      |          |        | count  | count    | count     |
 
 Example:
 
 ```console
 $ head imported_pages_20230209_20240123.csv
-"date","hostname","page","visits","visitors","pageviews","exits","time_on_page"
-"2023-02-09","plausible.io","/docs/script-extensions",8,8,9,4,247
-"2023-02-09","plausible.io","/docs/spa-support",1,1,1,1,0
-"2023-02-09","plausible.io","/docs/stats-api",8,7,11,2,1544
-"2023-02-09","plausible.io","/docs/goal-conversions",9,9,10,2,381
-"2023-02-09","plausible.io","/docs/visibility",1,1,1,1,0
-"2023-02-09","plausible.io","/docs/sites-api",3,3,3,1,35
-"2023-02-09","plausible.io","/docs/error-pages-tracking-404",3,3,3,1,8
-"2023-02-09","plausible.io","/docs/webflow-integration-draft",1,1,2,1,565
-"2023-02-09","plausible.io","/docs/guided-tour",5,5,5,3,6
+"date","hostname","page","visits","visitors","pageviews"
+"2023-02-09","plausible.io","/docs/script-extensions",8,8,9
+"2023-02-09","plausible.io","/docs/spa-support",1,1,1
+"2023-02-09","plausible.io","/docs/stats-api",8,7,11
+"2023-02-09","plausible.io","/docs/goal-conversions",9,9,10
+"2023-02-09","plausible.io","/docs/visibility",1,1,1
+"2023-02-09","plausible.io","/docs/sites-api",3,3,3
+"2023-02-09","plausible.io","/docs/error-pages-tracking-404",3,3,3
+"2023-02-09","plausible.io","/docs/webflow-integration-draft",1,1,2
+"2023-02-09","plausible.io","/docs/guided-tour",5,5,5
 ```
 
 #### imported_sources


### PR DESCRIPTION
This PR removes references to time on page in CSV exports/imports as it's no longer being exported / imported. 

Related: https://github.com/plausible/analytics/pull/4051