### PR TITLE
Mention add-file-types in file-downloads-tracking.md

### DIFF
--- a/docs/file-downloads-tracking.md
+++ b/docs/file-downloads-tracking.md
@@ -89,4 +89,4 @@ You can also specify a custom list of file types to track with a `file-types` at
 <script defer file-types="js,py" data-domain="yourdomain.com" src="https://plausible.io/js/script.file-downloads.js"></script>
 ```
 
-Using the `file-types` attribute will override our default list and only your custom file type downloads will be tracked.
+Using the `file-types` attribute will override our default list and only your custom file type downloads will be tracked. If you want to add custom file type downloads without overriding the default list you can use `add-file-types` instead.


### PR DESCRIPTION
In [the source code](https://github.com/plausible/analytics/blob/master/tracker/src/customEvents.js#L89) `add-file-types` is also available to add an extension to the list. But this isn't documented anywhere.

This PR adds a line to the documentation to mention that the `add` variant can also be used if you only want to add an extra extension to the list.