### PR TITLE
integration-guides: Move apps/widgets to own page

### DIFF
--- a/docs/apps-widgets.md
+++ b/docs/apps-widgets.md
@@ -19,3 +19,7 @@ If you're looking to access your Plausible dashboard or stats outside of a web b
 ## Linux
 
 * [Tally](https://flathub.org/apps/com.cassidyjames.plausible) by [Cassidy James Blaede](https://cassidyjames.com): hybrid native + web app that wraps the Plausible web app in a native UI, integrating better with desktop operating systems.
+
+---
+
+Let us know about any other apps or widgets that you've built and we will feature them in this list. Thanks for your support!

--- a/docs/apps-widgets.md
+++ b/docs/apps-widgets.md
@@ -1,0 +1,21 @@
+---
+title: Apps & Widgets
+---
+
+If you're looking to access your Plausible dashboard or stats outside of a web browser (e.g. from a desktop or mobile device), here are some options thanks to members of our community. Here they are in alphabetical order:
+
+## Apple platforms (iOS, iPadOS, macOS, tvOS, etc.)
+
+* [Glance for Plausible](https://testflight.apple.com/join/hG0MV7FC): A small app which lets you view your Plausible stats right on your iOS device. Built and maintained by Alexander Weiß.
+
+* [iOS widget](https://gist.github.com/linuz90/ac969cdfe9bd92af0b306c43caee8d0c) to display the total visitors count for today and the live visitors count with Plausible and Scriptable. Built and maintained by [Fabrizio Rinaldi](https://gist.github.com/linuz90).
+
+* [Metrics iOS Widget](https://santiviquez.gumroad.com/l/xLrcq) by Santiago Víquez
+
+* [Numerics Dashboards for Plausible](https://cynapse.com/numerics-integrations/plausible-dashboards/): Track your Plausible KPIs with Numerics Dashboards on your iPhone, iPad, Mac, Apple TV and Apple Watch.
+
+* [Staat](https://apps.apple.com/app/staat/id6451257773) by Andraz Polajzer
+
+## Linux
+
+* [Tally](https://flathub.org/apps/com.cassidyjames.plausible) by [Cassidy James Blaede](https://cassidyjames.com): hybrid native + web app that wraps the Plausible web app in a native UI, integrating better with desktop operating systems.

--- a/docs/integration-guides.md
+++ b/docs/integration-guides.md
@@ -344,16 +344,6 @@ A [TypeDoc Plausible plugin](https://typedoc-plausible.8hob.io/) that integrates
 
 We have a WordPress plugin that makes the integration with WordPress nice and easy. [Here's how to get started with our WordPress plugin](https://plausible.io/wordpress-analytics-plugin).
 
-## iOS apps and widgets for quick overview of your stats
-
-* [Glance for Plausible](https://testflight.apple.com/join/hG0MV7FC): A small app which lets you view your Plausible stats right on your iOS device. Built and maintained by Alexander Weiß.
-
-* [Numerics Dashboards for Plausible](https://cynapse.com/numerics-integrations/plausible-dashboards/): Track your Plausible KPIs with Numerics Dashboards on your iPhone, iPad, Mac, Apple TV and Apple Watch.
-
-* [iOS widget](https://gist.github.com/linuz90/ac969cdfe9bd92af0b306c43caee8d0c) to display the total visitors count for today and the live visitors count with Plausible and Scriptable. Built and maintained by [Fabrizio Rinaldi](https://gist.github.com/linuz90).
-
-* [Metrics iOS Widget](https://santiviquez.gumroad.com/l/xLrcq) by Santiago Víquez
-
-* [Staat](https://apps.apple.com/app/staat/id6451257773) by Andraz Polajzer
+---
 
 Let us know about any other integrations that you've built and we will feature them in this list. Thanks for your support!


### PR DESCRIPTION
…and add Tally for Linux. These feel like they belong on their own page instead of stuck at the bottom of the integrations page, since they're ways to access your Plausible stats from another platform, _not_ ways to integrate Plausible Analytics tracking into a site/app/etc.

As suggested at https://github.com/plausible/analytics/discussions/4141#discussioncomment-9554400