### PR TITLE
Fix tracking js file url

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,7 +7,7 @@ module.exports = {
   trailingSlash: false,
   projectName: 'docs',
   scripts: [
-    {src: 'js/tracking.js', defer: true}
+    {src: '/docs/js/tracking.js', defer: true}
   ],
   themeConfig: {
     colorMode: {


### PR DESCRIPTION
Tracking on the docs page was broken ~3 weeks ago, when I deployed a new tracking script. The script src was working locally with the path `js/tracking.js`, but on production, it requires the docs subfolder prefix.

Currently the request is made to https://plausible.io/js/tracking.js which is indeed a 404. The correct url is https://plausible.io/docs/js/tracking.js.