### PR TITLE
Fix examples-related `npm run build` failure

### DIFF
--- a/docs/stats-api-v2.md
+++ b/docs/stats-api-v2.md
@@ -9,12 +9,13 @@ import {Required, Optional} from '../src/js/api-helpers.js';
 import Examples, { ExamplesTip } from '../src/js/examples.js';
 import CodeBlock from '@theme/CodeBlock';
 import { SiteContextProvider } from '../src/js/sites.js';
+import BrowserOnly from '@docusaurus/BrowserOnly';
 
 :::warning[Beta feature]
 Please be advised that this feature is currently in beta phase. It might change or break in the coming months as it is refined.
 :::
 
-Plausible Stats API v2 is a powerful single endpoint HTTP interface to **view historical and real-time stats**. In a nutshell, the endpoint `/api/v2/query` accepts both simple and complex stats queries in the POST request body and returns the metrics as JSON. 
+Plausible Stats API v2 is a powerful single endpoint HTTP interface to **view historical and real-time stats**. In a nutshell, the endpoint `/api/v2/query` accepts both simple and complex stats queries in the POST request body and returns the metrics as JSON.
 
 [Try it now for your own site!](#examples)
 
@@ -285,6 +286,7 @@ The query that was executed, after manipulations performed on the backend.
 
 ## Examples
 
+<BrowserOnly>
 <SiteContextProvider>
 
 <ExamplesTip />
@@ -364,3 +366,4 @@ In this example, imported data could not be included due to dimension and filter
 
 
 </SiteContextProvider>
+</BrowserOnly>


### PR DESCRIPTION
Examples are interactive and cant be pre-built by docusaurus