### PR TITLE
Stats API Playground: Show errors when invalid JSON

### DIFF
--- a/src/js/apiv2-editor.tsx
+++ b/src/js/apiv2-editor.tsx
@@ -144,7 +144,7 @@ export async function postQuery(query: string): Promise<[Response, string]> {
   try {
     response = await fetch('/api/docs/query', {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", "Accept": "application/json" },
       body: query
     })
 

--- a/src/js/apiv2-playground.tsx
+++ b/src/js/apiv2-playground.tsx
@@ -56,7 +56,7 @@ export function ApiV2Playground() {
         <div>
           <hr />
           <h3>Response</h3>
-          <p>Status: <code>{response.status}</code> - <code>{response.statusText}</code></p>
+          <p>Status code: <code>{response.status}</code></p>
           <JsonSchemaEditor
             readOnly
             value={response.data}


### PR DESCRIPTION
Currently, no feedback is given to the user when they run an invalid JSON query in playground.

This is related to weirdness in JSON body parsing in the main repo. By setting `Accept` header, this issue goes away and we provide proper feedback.

Ref: https://3.basecamp.com/5308029/buckets/26383192/card_tables/cards/7898119573 