### PR TITLE
Add community browser extension Plausible Shield that shields traffic

### DIFF
--- a/docs/excluding-localstorage.md
+++ b/docs/excluding-localstorage.md
@@ -72,3 +72,7 @@ For the styled version of this page, you'll need to download a <a target="_blank
 (If you'd prefer a light-theme for this page, you can delete the `dark` class from line 1 of the above HTML file)
 
 For the unstyled/bare version, you'll just need to download a <a target="_blank" download="index.html" href="/docs/exclusion-examples/exclude-bare.html">HTML file</a>, and make it available on your website with any CSS you choose to add.
+
+## Use a community browser extension to exclude all of your browsers
+
+[Plausible Shield](https://www.goodaddon.com/plausible-shield/) is a browser extension, developed and maintained by [GoodAddon](https://www.goodaddon.com), that saves your excluded websites and syncs them across browser instances. If you use multiple browser instances and sync between them, you may find this browser extension helpful.


### PR DESCRIPTION
[Plausible Shield](https://www.goodaddon.com/plausible-shield/) allows a user to save a list of URL prefixes in browser and sync them via browser syncs. This can be helpful for those who owns multiple devices.

The underlying mechanics is to set the `localStorage` flag before the browser visiting a page under that URL.

Note that people can't specify a wild card `*` and abuse this browser extension to block all Plausible tracking site: The browser extension specifically requires the user to specify the portion of URL such that the full host name is known.