### PR TITLE
Add fetch-with-keepalive support to docs

### DIFF
--- a/static/js/tracking.js
+++ b/static/js/tracking.js
@@ -2,6 +2,7 @@ const script = document.createElement('script')
 
 script.defer = true
 script.dataset.domain = 'plausible.io'
+script.dataset.allowFetch = 'true'
 script.src = 'https://plausible.io/js/script.pageview-props.pageleave.js'
 script.setAttribute('event-browser_language', navigator.language || navigator.userLanguage)
 


### PR DESCRIPTION
Companion PR to https://github.com/plausible/analytics/pull/5005

Tested locally by modifying the file so:

```diff
--- a/static/js/tracking.js
+++ b/static/js/tracking.js
@@ -1,9 +1,10 @@
 const script = document.createElement('script')
 
 script.defer = true
-script.dataset.domain = 'plausible.io'
+script.dataset.domain = 'dummy.site'
 script.dataset.allowFetch = 'true'
-script.src = 'https://plausible.io/js/script.pageview-props.pageleave.js'
+script.dataset.apiHost = 'http://localhost:8000'
+script.src = 'http://localhost:8000/js/script.local.pageleave.pageview-props.js'
 script.setAttribute('event-browser_language', navigator.language || navigator.userLanguage)
 
 document.getElementsByTagName('head')[0].appendChild(script)
```