### PR TITLE
feat: Add Astro content loader to integration guides

### DIFF
--- a/docs/integration-guides.md
+++ b/docs/integration-guides.md
@@ -34,6 +34,10 @@ Our events API can be used to record pageviews and custom events server side wit
 
 [Android SDK](https://github.com/wbrawner/plausible-android): An Android SDK for Plausible Analytics.
 
+## Astro
+
+[Astro Plausible loader](https://github.com/LekoArts/astro-loaders/tree/main/packages/plausible): This package provides a Plausible content loader for Astro's content layer. You can access the Stats API v2 to view historical and real-time stats of your website.
+
 ## Bridgetown
 
 [Bridgetown](https://rubygems.org/gems/bridgetown-plausible): this plugin provides the plausible Liquid tag & ERB helper to your Bridgetown site.


### PR DESCRIPTION
Hello!

I've recently published https://github.com/LekoArts/astro-loaders/tree/main/packages/plausible which is a loader for Astro's content layer: https://docs.astro.build/en/guides/content-collections/

You can think of the content layer as a database that gets filled up during build by requests that people make inside their pages. This Plausible content loader allows people to query the Stats API v2 during build and then use the data inside a SSG page, so no API calls in the browser.

The whole `query` interface is type-safe as I converted the information in the docs to a Typescript schema.