### PR TITLE
Update 404 tracking examples

### DIFF
--- a/docs/error-pages-tracking-404.md
+++ b/docs/error-pages-tracking-404.md
@@ -41,7 +41,7 @@ Your Plausible tracking snippet should be inserted into [the Header (`<head>`) s
 Add this code to your 404 page. For instance, if you're using WordPress, your 404 page template will be called `404.php`. It will be located within your theme files.
 
 ```html
-<script>document.addEventListener('DOMContentLoaded', function () { plausible('404', { props: { path: document.location.pathname } }); });</script>
+<script>document.addEventListener('DOMContentLoaded', function () { plausible('404'); });</script>
 ```
 
 You can place this code anywhere in the `<head>` or `<body>` section of your 404 page template.

--- a/docs/google-tag-manager.md
+++ b/docs/google-tag-manager.md
@@ -95,7 +95,7 @@ That's it! Now you can go to your website and verify whether Plausible Analytics
 5. Create a new GTM Tag called "**Page Not Found Tag**" of type "**Custom HTML**" and paste the following code:
 
 ```javascript
-<script type="text/javascript">window.plausible("404", { props: { path: document.location.pathname } });</script>
+<script type="text/javascript">window.plausible("404");</script>
 ```
 
 6. Publish all changes.


### PR DESCRIPTION
Setting props.path is not necessary after https://github.com/plausible/analytics/pull/5559. It is automatically synced to be the same as the resolved pathname of the event. 