### PR TITLE
Fix poor color contrast for `warning` alerts in dark mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -31,6 +31,14 @@
   --ra-admonition-icon-color: var(--ifm-color-gray-900);
 }
 
+[data-theme='dark'] .alert--warning {
+  color: var(--ifm-color-gray-900);
+}
+
+[data-theme='dark'] .alert--warning svg {
+  fill: var(--ifm-color-gray-900);
+}
+
 .code-button {
   font-size: 24px;
   line-height: 1em;


### PR DESCRIPTION
## Summary
This PR improves the readability of warning alerts in dark mode.

The current text/background color combination (#fff8e6 on #ffdd80) fails all WCAG contrast requirements ([see contrast check](https://coolors.co/contrast-checker/fff8e6-ffdd80)).

This update overrides the styles to use #1c1e21 text on the same background (#ffdd80), which [passes all WCAG levels](https://coolors.co/contrast-checker/1c1e21-ffdd80).

## Screenshots
Before:
<img width="983" height="119" alt="Warning alert before" src="https://github.com/user-attachments/assets/26820a61-3a1b-4868-b8f7-67831e8f8091" />

After:
<img width="978" height="115" alt="Warning alert after" src="https://github.com/user-attachments/assets/60613f1f-2e10-4f4d-a900-2d2ad6e4ba81" />