### PR TITLE
Update dogfooding tracker URL to new format

### DIFF
--- a/static/js/tracking.js
+++ b/static/js/tracking.js
@@ -1,4 +1,4 @@
-var scriptSrc = "https://plausible.io/js/s-6_srOGVV9SLMWJ1ZpUAbG.js"
+var scriptSrc = "https://plausible.io/js/pa-6_srOGVV9SLMWJ1ZpUAbG.js"
 
 window.plausible=window.plausible||function(){(window.plausible.q=window.plausible.q||[]).push(arguments)},window.plausible.init=function(i){window.plausible.o=i||{}};var script=document.createElement("script");script.type="text/javascript",script.defer=!0,script.src=scriptSrc;var r=document.getElementsByTagName("script")[0];r.parentNode.insertBefore(script,r);
 


### PR DESCRIPTION
After https://github.com/plausible/analytics/pull/5621, the v2 script should be accessed from a new URL (although there's a fallback for old URLs ATM)