### PR TITLE
Update GTM docs with missing steps

### DIFF
--- a/docs/google-tag-manager.md
+++ b/docs/google-tag-manager.md
@@ -98,7 +98,9 @@ That's it! Now you can go to your website and verify whether Plausible Analytics
 <script type="text/javascript">window.plausible("404");</script>
 ```
 
-6. Publish all changes.
+6. Assign the "Page Not Found Trigger" to the "Page Not Found Tag"
+
+7. Publish all changes.
 
 ## Track custom events
 


### PR DESCRIPTION
Add missing step in google tag manager docs where the newly created trigger needs to be assigned to the newly created tag.